### PR TITLE
chore: refine prettier related code

### DIFF
--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -1,4 +1,3 @@
-// .prettierrc.mjs
 /** @type {import("prettier").Config} */
 export default {
   plugins: ["prettier-plugin-astro"],

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,4 @@
 {
-  "recommendations": ["astro-build.astro-vscode"],
+  "recommendations": ["astro-build.astro-vscode", "esbenp.prettier-vscode"],
   "unwantedRecommendations": []
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "format": "prettier --write '**/*.{astro,js,mjs,json,ts,yml,yaml}' --plugin=prettier-plugin-astro",
+    "format": "prettier --write '**/*.{astro,js,mjs,json,ts,yml,yaml}'",
     "prepare": "husky install"
   },
   "engines": {


### PR DESCRIPTION
コードリーディングしながら、Prettier関連のコードを修正しました。

- `.vscode/settings.json` で設定されているPrettierのExtensionがリコメンドされていなかったので追加
- 不要なコメントを削除
- 不要なPrettier CLIのインラインオプションを削除（`.prettierrc.mjs` に記述されているので）