### PR TITLE
chore: refine project settings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,8 @@ on:
   # Trigger the workflow every time you push to the `main` branch
   # Using a different branch name? Replace `main` with your branch’s name
   push:
-    branches: [main]
+    branches:
+      - main
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
@@ -22,10 +23,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Install, build, and upload your site
         uses: withastro/action@v2
-        with:
-          # path: . # The root location of your Astro project inside the repository. (optional)
-          # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
-          package-manager: pnpm@8 # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+        # with:
+        #   path: . # The root location of your Astro project inside the repository
+        #   node-version: 20 # Default
+        #   package-manager: # Determined by `packageManager` in `package.json`
 
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -1,23 +1,28 @@
-# 2024
-Go Conference 2024
+# Go Conference 2024 Website
 
 ## Getting Started
 
 **Prerequisites**
 
-- [Node.js](https://nodejs.org/en/download/) version 20.x higher
-- [pnpm](https://pnpm.io/installation) version 8.x higher
+- [Node.js](https://nodejs.org/en/download/): v20.x or higher
+- [pnpm](https://pnpm.io/installation): v8.x or higher (use [corepack](https://github.com/nodejs/corepack))
 
-1. Install dependencies.
+1. Enable corepack.
 
-```shell
-pnpm install
-```
+    ```shell
+    corepack enable
+    ```
 
-2. Start the development server.
+2. Install dependencies.
 
-```shell
-pnpm start
-```
+    ```shell
+    pnpm install
+    ```
+
+3. Start the development server.
+
+    ```shell
+    pnpm run dev
+    ```
 
 3. Open `http://localhost:4321` in your browser.

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "gocon2024",
   "type": "module",
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "dev": "astro dev",
-    "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
@@ -12,9 +12,9 @@
     "prepare": "husky install"
   },
   "engines": {
-    "node": ">=20",
-    "pnpm": ">=8"
+    "node": ">=20"
   },
+  "packageManager": "pnpm@8.15.4",
   "lint-staged": {
     "**/*.{astro,js,mjs,json,ts,yml,yaml}": "pnpm run format"
   },


### PR DESCRIPTION
コードリーディングしながら、プロジェクトとCIのコードを修正して、モダンにしてみました。
このPRは提案なので、マージするかどうか相談できれば幸いです（一部または全部など）。

- 念のため `package.json` に `private: true` を追加（[参考](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#private)）
- corepackを利用するように変更（[参考](https://github.com/nodejs/corepack)）
  - この変更により、全員が同じバージョンのpnpmを利用することを保証できます
  - READMEにcorepackの設定方法を追加
  - `engines.pnpm` のかわりに `packageManager` を設定
  - `withastro/action@v2` の `package-manager` オプションが `packageManager` を参照するように変更
- `package.json` で `start` と `dev` が重複しているので `start` を削除（`dev` の方がより一般的なので）
- その他コメントを編集

このPRでpnpmのバージョンを `package.json` で一括管理できるようになります。
一方、 `withastro/action@v2` ではNode.jsのバージョンを `package.json` の `engines.node` を参照させることができないようでしたので、upstreamにPRを出しておきました：https://github.com/withastro/action/pull/48