### PR TITLE
chore: refine format and import paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # build output
 dist/
+
 # generated types
 .astro/
 

--- a/src/components/Footer/index.astro
+++ b/src/components/Footer/index.astro
@@ -1,6 +1,6 @@
 ---
 import { Image } from "astro:assets";
-import { concatWithBase } from "../../utils/concatWithBase";
+import { concatWithBase } from "@utils/concatWithBase";
 ---
 
 <footer class="container">

--- a/src/components/Header/hamburger.astro
+++ b/src/components/Header/hamburger.astro
@@ -2,6 +2,7 @@
 interface Props {
   id?: string;
 }
+
 const { id } = Astro.props;
 ---
 

--- a/src/components/Header/index.astro
+++ b/src/components/Header/index.astro
@@ -1,7 +1,7 @@
 ---
 import { Image } from "astro:assets";
 import Hamburger from "@components/Header/hamburger.astro";
-import { concatWithBase } from "../../utils/concatWithBase";
+import { concatWithBase } from "@utils/concatWithBase";
 ---
 
 <header>

--- a/src/components/Header/index.astro
+++ b/src/components/Header/index.astro
@@ -1,6 +1,6 @@
 ---
 import { Image } from "astro:assets";
-import Hamburger from "./hamburger.astro";
+import Hamburger from "@components/Header/hamburger.astro";
 ---
 
 <header>

--- a/src/domain/constants.ts
+++ b/src/domain/constants.ts
@@ -1,1 +1,1 @@
-export const siteName = "Go Conference 2024";
+export const SITE_NAME = "Go Conference 2024" as const;

--- a/src/domain/constants.ts
+++ b/src/domain/constants.ts
@@ -1,1 +1,3 @@
+export const SITE_DESCRIPTION =
+  "Go Conference is a conference for Go programming language users." as const;
 export const SITE_NAME = "Go Conference 2024" as const;

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,4 +1,4 @@
-import { ui, defaultLang } from "./ui";
+import { ui, defaultLang } from "@i18n/ui";
 
 export function getLangFromUrl(url: URL) {
   const [, lang] = url.pathname.split("/");

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,5 +1,5 @@
 ---
-import { SITE_NAME } from "@domain/constants";
+import { SITE_DESCRIPTION, SITE_NAME } from "@domain/constants";
 import { getLangFromUrl } from "@i18n/utils";
 import Header from "@components/Header/index.astro";
 import Footer from "@components/Footer/index.astro";
@@ -7,12 +7,14 @@ import "@styles/global.css";
 
 interface Props {
   title?: string;
+  description?: string;
 }
 
 const lang = getLangFromUrl(Astro.url);
-const { title } = Astro.props;
-const description =
-  "Go Conference is a conference for Go programming language users.";
+const { title, description } = Astro.props;
+
+const _title = title ? `${title} | ${SITE_NAME}` : SITE_NAME;
+const _description = description || SITE_DESCRIPTION;
 ---
 
 <html lang={lang}>
@@ -25,17 +27,17 @@ const description =
     />
     <meta name="viewport" content="width=device-width" />
     <slot name="title">
-      <title>{title ? `${title} | ${SITE_NAME}` : SITE_NAME}</title>
+      <title>{_title}</title>
     </slot>
 
-    <meta name="title" content={SITE_NAME} />
-    <meta name="description" content={description} />
+    <meta name="title" content={_title} />
+    <meta name="description" content={_description} />
 
     <meta property="og:site_name" content={SITE_NAME} />
     <meta property="og:type" content="website" />
     <meta property="og:url" content={Astro.url} />
-    <meta property="og:title" content={SITE_NAME} />
-    <meta property="og:description" content={description} />
+    <meta property="og:title" content={_title} />
+    <meta property="og:description" content={_description} />
     <meta
       property="og:image"
       content={new URL(
@@ -46,8 +48,8 @@ const description =
 
     <meta property="twitter:card" content="summary" />
     <meta property="twitter:url" content={Astro.url} />
-    <meta property="twitter:title" content={SITE_NAME} />
-    <meta property="twitter:description" content={description} />
+    <meta property="twitter:title" content={_title} />
+    <meta property="twitter:description" content={_description} />
     <meta
       property="twitter:image"
       content={new URL(

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,7 +4,7 @@ import { getLangFromUrl } from "@i18n/utils";
 import Header from "@components/Header/index.astro";
 import Footer from "@components/Footer/index.astro";
 import "@styles/global.css";
-import { concatWithBase } from "../utils/concatWithBase";
+import { concatWithBase } from "@utils/concatWithBase";
 
 interface Props {
   title?: string;

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,9 +1,9 @@
 ---
-import { siteName } from "../domain/constants";
-import { getLangFromUrl } from "../i18n/utils";
-import Header from "../components/Header/index.astro";
-import Footer from "../components/Footer/index.astro";
-import "../styles/global.css";
+import { SITE_NAME } from "@domain/constants";
+import { getLangFromUrl } from "@i18n/utils";
+import Header from "@components/Header/index.astro";
+import Footer from "@components/Footer/index.astro";
+import "@styles/global.css";
 
 interface Props {
   title?: string;
@@ -25,16 +25,16 @@ const description =
     />
     <meta name="viewport" content="width=device-width" />
     <slot name="title">
-      <title>{title ? `${title} | ${siteName}` : siteName}</title>
+      <title>{title ? `${title} | ${SITE_NAME}` : SITE_NAME}</title>
     </slot>
 
-    <meta name="title" content={siteName} />
+    <meta name="title" content={SITE_NAME} />
     <meta name="description" content={description} />
 
-    <meta property="og:site_name" content={siteName} />
+    <meta property="og:site_name" content={SITE_NAME} />
     <meta property="og:type" content="website" />
     <meta property="og:url" content={Astro.url} />
-    <meta property="og:title" content={siteName} />
+    <meta property="og:title" content={SITE_NAME} />
     <meta property="og:description" content={description} />
     <meta
       property="og:image"
@@ -46,7 +46,7 @@ const description =
 
     <meta property="twitter:card" content="summary" />
     <meta property="twitter:url" content={Astro.url} />
-    <meta property="twitter:title" content={siteName} />
+    <meta property="twitter:title" content={SITE_NAME} />
     <meta property="twitter:description" content={description} />
     <meta
       property="twitter:image"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from "../layouts/Base.astro";
+import BaseLayout from "@layouts/Base.astro";
 ---
 
 <BaseLayout title="Home">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from "@layouts/Base.astro";
-import { concatWithBase } from "../utils/concatWithBase";
+import { concatWithBase } from "@utils/concatWithBase";
 ---
 
 <BaseLayout title="Home">

--- a/src/pages/sponsors/[id].astro
+++ b/src/pages/sponsors/[id].astro
@@ -1,6 +1,8 @@
 ---
 import { Image } from "astro:assets";
 import { getEntry } from "astro:content";
+import BaseLayout from "@layouts/Base.astro";
+
 export async function getStaticPaths() {
   const sponsors = await getEntry("sponsors", "data");
   return sponsors.data.map((sponsor) => ({
@@ -8,8 +10,8 @@ export async function getStaticPaths() {
     props: { sponsor },
   }));
 }
+
 const { sponsor } = Astro.props;
-import BaseLayout from "../../layouts/Base.astro";
 ---
 
 <BaseLayout title={sponsor.name}>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
       "@i18n/*": ["src/i18n/*"],
       "@layouts/*": ["src/layouts/*"],
       "@styles/*": ["src/styles/*"],
+      "@utils/*": ["src/utils/*"],
     },
   },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,5 +2,14 @@
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
     "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"],
+      "@content/*": ["src/content/*"],
+      "@domain/*": ["src/domain/*"],
+      "@i18n/*": ["src/i18n/*"],
+      "@layouts/*": ["src/layouts/*"],
+      "@styles/*": ["src/styles/*"],
+    },
   },
 }


### PR DESCRIPTION
コードリーディングしながら、フォーマットとインポートパスを修正してみました。
このPRは提案なので、マージするかどうか相談できれば幸いです（一部または全部など）。

- 各所に改行を追加
- `import` 文がファイル先頭に来るように修正
- `import` 文で相対パスが多くなっているような気がしたので、エイリアスを設定（[参考](https://docs.astro.build/en/guides/aliases/)）
  - 同階層のファイルをimportしているときは、エイリアスを使用すると逆にパスが長くなって冗長に見えたので、意図的に相対パスを残していますが、すべてエイリアスに統一した方がいいでしょうか？
    - 例えば `src/components/Header/index.astro` と `src/components/Header/hamburger.astro` についてです
  -  Viteの [`resolve.alias`](https://vitejs.dev/config/shared-options#resolve-alias) にも設定しなくていいの？と思って調べたところ、Astro内部で `tsconfig.json` の設定をもとに独自Vite Pluginでエイリアスを解決しているので問題ないようです（[参考](https://github.com/withastro/astro/blob/4dcfa2bd90027dff9240aaadcadb1e4d6516c01b/packages/astro/src/vite-plugin-config-alias/index.ts)）
- `siteName` がグローバル定数のような感じなので大文字スネークケースにして `as const` を追加（[参考](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions), [参考](https://typescriptbook.jp/reference/values-types-variables/const-assertion)）
