### PR TITLE
feat: add link to connpass page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,6 +39,17 @@ import { concatWithBase } from "@utils/concatWithBase";
         <td>Goに興味・関心のあるエンジニア(初級～上級)</td>
       </tr>
       <tr>
+        <th>参加方法</th>
+        <td
+          ><a
+            href="https://gocon.connpass.com/event/314876/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >https://gocon.connpass.com/event/314876/</a
+          >
+        </td>
+      </tr>
+      <tr>
         <th>言語</th>
         <td>日本語・英語 (通訳はありません)</td>
       </tr>


### PR DESCRIPTION
# WHY
参加方法がなかったので当日会場に行けば参加できるようにも見えそうです。

# WHAT
connpassへのリンクを貼りました。
文言はとくに考えていなかったので雑にURLにしてます。

# 参考
Ruby Kaigiは「Register Now」というボタンでリンクしてました。
https://rubykaigi.org/2024/